### PR TITLE
Fix some broken URLs

### DIFF
--- a/Docs/GettingStarted/DevIntro.md
+++ b/Docs/GettingStarted/DevIntro.md
@@ -80,10 +80,10 @@ To get this sample working, you'll need:
 + A BLE-enabled mbed board.
 
 <span style="background-color:#E6E6E6; border:1px solid #000;display:block; height:100%; padding:10px">
-**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
+**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](http://developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
 </span>
 
-+ A user on [developer.mbed.org](developer.mbed.org) to access the compiler.
++ A user on [developer.mbed.org](http://developer.mbed.org) to access the compiler.
 
 If you’re familiar with mbed and our compiler, you can get the beacon working in just a few minutes:
 

--- a/Docs/GettingStarted/HeartRate.md
+++ b/Docs/GettingStarted/HeartRate.md
@@ -60,7 +60,7 @@ The service has [three characteristics](https://developer.bluetooth.org/Technolo
 
 * **Heart Rate Control Point**: receives a value from the user when the user wants to reset the *Energy Expanded* measurement.
 
-It is important to understand that this demo fakes a heart rate value; it does not interact with a physical heart rate sensor to fetch real data. To work with a real heart rate application, we would have had to create a very specific example, which would have been harder to learn from. You should be able to modify the general demo to fit any app that you want to work with if you have a real heart rate sensor. Please check [mbed.org](developer.mbed.org) before you start working - there may already be code available for your heart rate sensor.
+It is important to understand that this demo fakes a heart rate value; it does not interact with a physical heart rate sensor to fetch real data. To work with a real heart rate application, we would have had to create a very specific example, which would have been harder to learn from. You should be able to modify the general demo to fit any app that you want to work with if you have a real heart rate sensor. Please check [mbed.org](http://developer.mbed.org) before you start working - there may already be code available for your heart rate sensor.
 
 ##Understanding the Code
 

--- a/Docs/GettingStarted/IntroSamples.md
+++ b/Docs/GettingStarted/IntroSamples.md
@@ -12,7 +12,7 @@ For all of these, you should have:
 
 1. A BLE-enabled mbed board. But don't worry if you don't have one yet - we'll show you how it would have worked.
 
-2. A user account on [developer.mbed.org](developer.mbed.org) to see the compiler. We recommend you get access to the compiler even if you don't have a board yet, so that you can play along with the example.
+2. A user account on [developer.mbed.org](http://developer.mbed.org) to see the compiler. We recommend you get access to the compiler even if you don't have a board yet, so that you can play along with the example.
 
 Some tutorials will have additional requirements, such as phone apps or additional hardware. These will be listed for each tutorial as needed.
 

--- a/Docs/GettingStarted/URIBeacon.md
+++ b/Docs/GettingStarted/URIBeacon.md
@@ -29,10 +29,10 @@ To get this going, you'll need:
 + A BLE-enabled mbed board, but don't worry if you don't have one yet - we'll show you how it would have worked.
 
 <span style="background-color:#E6E6E6; border:1px solid #000;display:block; height:100%; padding:10px">
-**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
+**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](http://developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
 </span>
 
-+ A user account on [developer.mbed.org](developer.mbed.org) to access the compiler. We recommend you get access to the compiler even if you don't have a board yet, so that you can play along with the example.
++ A user account on [developer.mbed.org](http://developer.mbed.org) to access the compiler. We recommend you get access to the compiler even if you don't have a board yet, so that you can play along with the example.
 
 ##Quick Guide
 
@@ -47,7 +47,7 @@ If you’re familiar with mbed and our compiler, you can get the beacon working 
 5. Compile the code. It will be downloaded to your Downloads folder (on some browsers you may need to specify a download location). <br />**Note:** make sure you've selected the correct platform as the compilation target. The platform is shown on the right-hand top corner of the compiler. If you're seeing the wrong platform, click it to open the Select Platform window.
 
 6. Drag and drop the compiled file to your board as it appears in the file explorer. 
-</br>**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
+</br>**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](http://developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
 
 7. Restart the board.
 
@@ -76,7 +76,7 @@ To select a board for the program:
 </span>
 
 <span style="background-color:#E6E6E6; border:1px solid #000;display:block; height:100%; padding:10px">
-**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
+**Note:** if your board appears as JLINK instead of mbed, please go to the [platform page](http://developer.mbed.org/platforms/) for your board and follow the firmware update instructions.
 </spa[n>
 
 * In your file browser, double-click the board to see its files. By default, every board has an HTML file. 

--- a/Docs/InDepth/BLEInDepth.md
+++ b/Docs/InDepth/BLEInDepth.md
@@ -157,7 +157,7 @@ Creating a characteristic on mbed is very easy, because ``BLE_API`` offers C++ a
 ```
 
 <span style="background-color:#E6E6E6; border:1px solid #000;display:block; height:100%; padding:10px">
-For a full walkthrough of characteristic creation on mbed, see our [input service template](AdvSamples/InputButton/#the-button-state-characteristic).
+For a full walkthrough of characteristic creation on mbed, see our [input service template](/AdvSamples/InputButton/#the-button-state-characteristic).
 </span>
 
 A characteristic is fully defined by its declaration, value and descriptor:
@@ -180,13 +180,13 @@ Here's an example of creating a read/write characteristic (a characteristic that
 ```
 
 <span style="background-color:#E6E6E6; border:1px solid #000;display:block; height:100%; padding:10px">
-For information about creating a read/write characteristic on mbed, see our [actuator service template](AdvSamples/LEDReadWrite/#the-led-state-characteristic).
+For information about creating a read/write characteristic on mbed, see our [actuator service template](/AdvSamples/LEDReadWrite/#the-led-state-characteristic).
 </span>
 
 Some characteristics are two-way entities. That means the server (BLE peripheral) can both update them itself and receive new values for them from the client (phone). This two-way traffic makes BLE interactive: the user sends a new value to one or more characteristics and the device responds to these new values. For example, when a URI Beacon device is turned on, it goes into a temporary *configuration mode*, giving us a chance to update the values of its characteristics (containing the data it will later advertise). 
 
 <span style="background-color:#E6E6E6; border:1px solid #000;display:block; height:100%; padding:10px">
-For information about the configuration mode, see the [URI Beacon Advanced Features page](AdvSamples/URIBeaconAdv/).
+For information about the configuration mode, see the [URI Beacon Advanced Features page](/AdvSamples/URIBeaconAdv/).
 </span>
 
 The service definition states, for each characteristic, whether clients have permission to write to that characteristic. This is done when setting up the GATT server on the peripheral. In our example, the *configuration mode* states that the advertising information is read/write, and the *advertising mode* states that it is read-only. The same characteristic can, therefore, have two different permissions, depending on the device's mode. 

--- a/Docs/InDepth/Debugging.md
+++ b/Docs/InDepth/Debugging.md
@@ -387,7 +387,7 @@ Note that:
 
 ##Sniffers
 
-Third-party sniffers can intercept the BLE communication itself and show us what's being sent (and how). For example, we could see if our [connection parameters](InDepth/ConnectionParameters/) are being honoured. 
+Third-party sniffers can intercept the BLE communication itself and show us what's being sent (and how). For example, we could see if our [connection parameters](/InDepth/ConnectionParameters/) are being honoured.
 
 Sniffing radio activity can now be done with smart phone apps like [Bluetooth HCI Logger (for Android)](https://play.google.com/store/apps/details?id=com.android_rsap.logger&hl=en). These generate logs that can be analysed with tools like [Wireshark](https://www.wireshark.org/).
 

--- a/Docs/InDepth/Prototyping.md
+++ b/Docs/InDepth/Prototyping.md
@@ -64,4 +64,4 @@ The UART Service can be used to debug directly over the BLE connection (with the
 ###Third-Party Sniffers
 </a>
 
-Third party sniffers can intercept BLE communication on your phone or on dedicated hardware. For more information, see our [debugging with sniffers section](InDepth/Debugging/#sniffers).
+Third party sniffers can intercept BLE communication on your phone or on dedicated hardware. For more information, see our [debugging with sniffers section](/InDepth/Debugging/#sniffers).


### PR DESCRIPTION
This patch fixes a couple of broken links, by simply replacing relative
with absolute URLs where necessary.
I used a crawler script to scan the whole docs online, so hopefully I got
all of them.
