### PR TITLE
Update BLE_API.md to point to mbed OS 5 examples, not mbed OS 3

### DIFF
--- a/Docs/Introduction/BLE_API.md
+++ b/Docs/Introduction/BLE_API.md
@@ -58,7 +58,7 @@ The class's member functions can be divided by purpose:
 
 ##Sample mbed BLE apps
 
-We have examples of [mbed OS BLE apps, along with documentation](https://github.com/ARMmbed/ble-examples).
+We have examples of [mbed OS BLE apps, along with documentation](https://github.com/ARMmbed/mbed-os-example-ble).
 
 ##Full BLE_API documentation
 

--- a/Docs/Introduction/BLE_API.md
+++ b/Docs/Introduction/BLE_API.md
@@ -58,7 +58,7 @@ The class's member functions can be divided by purpose:
 
 ##Sample mbed BLE apps
 
-We have examples of [mbed OS BLE apps, along with documentation](https://github.com/ARMmbed/mbed-os-example-ble).
+We have examples of mbed OS BLE apps, along with documentation [for mbed OS 5](https://github.com/ARMmbed/mbed-os-example-ble) and [mbed OS 3](https://github.com/ARMmbed/ble-examples).
 
 ##Full BLE_API documentation
 


### PR DESCRIPTION
@iriark01 